### PR TITLE
fix: setSearchParams break current history state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export function useUrlSearchParams(
     if (typeof window === 'undefined' || !window.URL) return;
     const url = setQueryToCurrentUrl(newParams);
     if (window.location.search !== url.search) {
-      window.history.replaceState({}, '', url.toString());
+      window.history.replaceState(window.history.state, '', url.toString());
     }
     if (urlSearchParams.toString() !== url.searchParams.toString()) {
       forceUpdate({});


### PR DESCRIPTION
When I opened the syncToUrl config in pro-components's form component, I found my global history state was polluted by "{}". This will make a mistake in react-router's state management, causing the `useBlocker` in react-router not work.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/History/state), the default state value should be null. Such that the react router's `useBlock` would work as expected.